### PR TITLE
New /healthcheck route and better handling of sigterm

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
+    "@godaddy/terminus": "^4.3.1",
     "circleci-api": "^4.0.0",
     "express": "^4.17.1",
     "prom-client": "^11.3.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,12 @@
+import { createTerminus, HealthCheckError, TerminusOptions } from '@godaddy/terminus';
 import express from 'express';
-import { Server } from 'http';
+import { createServer, Server } from 'http';
 import Prometheus from 'prom-client';
 import { CircleCiClient } from './circleci-client';
 import { CircleCiExporter } from './circleci-exporter';
 import appConfig from './config';
 import logger from './logger';
 import { ScrapeStatus } from './scrape-status';
-import Signals = NodeJS.Signals;
 
 // Debug environment configuration
 logger.silly('Environment variables');
@@ -14,17 +14,50 @@ logger.silly(process.env);
 logger.silly('Configuration');
 logger.silly(appConfig);
 
-let server: Server | undefined;
-
 const pagingOptions = {
     limit: appConfig.scrape.buildsPerPage,
     maxPages: appConfig.scrape.maxPages,
     since: appConfig.scrape.since,
 };
+
 const exporter = new CircleCiExporter(new CircleCiClient(appConfig.circleci), new ScrapeStatus());
+const app = express();
+const server: Server = createServer(app);
+
+let initialScrapingFinished = false;
+
+async function healthCheck(): Promise<any> {
+    if (!initialScrapingFinished) {
+        throw new HealthCheckError('healthcheck failed', ['Initial scraping not finished']);
+    }
+    return {};
+}
+
+async function onSignal(): Promise<any> {
+    logger.info('caught signal. Starting cleanup');
+}
+
+async function onShutdown(): Promise<any> {
+    logger.info('cleanup finished, server is shutting down');
+}
+
+const terminusOptions: TerminusOptions = {
+    healthChecks: {
+        '/healthcheck': healthCheck,
+    },
+    signals: [ 'SIGINT', 'SIGTERM' ],
+    onSignal,
+    onShutdown,
+    logger: logger.info,
+};
+
+createTerminus(server, terminusOptions);
+
+server.listen(appConfig.http.port, async () => {
+    logger.info(`App server listening on port ${appConfig.http.port}!`);
+});
+
 exporter.export(pagingOptions).then(() => {
-    // Start the server only after the first metrics collection is done
-    const app = express();
     app.get('/metrics', async (_, res) => {
         logger.debug('/metrics hit');
 
@@ -37,31 +70,5 @@ exporter.export(pagingOptions).then(() => {
         res.set('Content-Type', Prometheus.register.contentType);
         res.end(Prometheus.register.metrics());
     });
-
-    server = app.listen(appConfig.http.port, async () => {
-        logger.info(`App server listening on port ${appConfig.http.port}!`);
-    });
+    initialScrapingFinished = true;
 }).catch(logger.error);
-
-// @ts-ignore
-function doScrape(): void {
-    exporter.export(pagingOptions).then(() => {
-        setTimeout(doScrape, 60_000);
-    }).catch(logger.error);
-}
-
-(['SIGINT', 'SIGTERM'] as Signals[]).forEach(signal => {
-    process.on(signal, () => {
-        logger.info(`Received signal ${signal}'`);
-        server && server.close(err => {
-            logger.info('Server is stopping');
-            err && logger.error(err);
-            process.exit(0);
-        });
-        // Make sure we forcefully stop the server even if server is still responding
-        setTimeout(() => {
-            logger.warn('Could not close connections in time, forcefully shutting down');
-            process.exit(0);
-        }, 2000);
-    });
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,6 +143,14 @@
   resolved "https://registry.yarnpkg.com/@equisoft/tslint-config/-/tslint-config-0.0.8.tgz#3c7b141af685479ff9cacf1fa9dfda8ca49c4f57"
   integrity sha512-jYpZOf2P8W4pck09N8IV2wRcIZasYbK/U3bFDKK7Bj51hhnVW2WH9JeaN4YIylzrp4O9rnUgCMh4L/PsrJUE9w==
 
+"@godaddy/terminus@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@godaddy/terminus/-/terminus-4.3.1.tgz#20bc24271df373ae362b3948c9dd95d22736b5c2"
+  integrity sha512-zChILIprb4nWTGJ/pXafbGZqJA7yB6JzFQp5f8PBR5B0cJ6f9Nd40ySLFTBzko+PEZgVaJlKrJi5gUQLTI9dpw==
+  dependencies:
+    es6-promisify "^6.0.0"
+    stoppable "^1.0.5"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -1355,6 +1363,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-promisify@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.1.0.tgz#32e3e7e796f924a6723f09ded24e71100ea57472"
+  integrity sha512-jCsk2fpfEFusVv1MDkF4Uf0hAzIKNDMgR6LyOIw6a3jwkN1sCgWzuwgnsHY9YSQ8n8P31HoncvE0LC44cpWTrw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -4032,6 +4045,11 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stoppable@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.1.0.tgz#32da568e83ea488b08e4d7ea2c3bcc9d75015d5b"
+  integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
On a remarqué en prod que le serveur continue à scraper même lorsqu'il reçoit un sigterm.

J'utilise maintenant la lib terminus pour mieux gérer les signaux.

Bonus, on a maintenant un /healthcheck